### PR TITLE
Add parallel image downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # glowing-octo-robot
 Codex sandbox
+
+## Image Downloader
+
+`image_downloader.py` is a simple script that downloads images in parallel.
+
+### Usage
+
+1. Create a text file with one image URL per line.
+2. Run the script specifying the URL file and destination directory:
+
+```bash
+python3 image_downloader.py urls.txt downloaded_images
+```
+
+Use `--workers` to control the number of concurrent downloads.

--- a/image_downloader.py
+++ b/image_downloader.py
@@ -1,0 +1,29 @@
+import argparse
+import concurrent.futures
+from pathlib import Path
+from urllib.request import urlopen
+
+
+def download_image(url: str, dest: Path) -> None:
+    """Download a single image to the destination directory."""
+    dest.mkdir(parents=True, exist_ok=True)
+    filename = url.split('/')[-1] or 'image'
+    target = dest / filename
+    with urlopen(url) as response, open(target, 'wb') as out_file:
+        out_file.write(response.read())
+
+
+def main(urls_file: Path, output_dir: Path, workers: int) -> None:
+    urls = [line.strip() for line in urls_file.read_text().splitlines() if line.strip()]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        for url in urls:
+            executor.submit(download_image, url, output_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Parallel image downloader")
+    parser.add_argument("urls_file", type=Path, help="Path to text file containing image URLs")
+    parser.add_argument("output_dir", type=Path, help="Directory where images will be saved")
+    parser.add_argument("--workers", type=int, default=4, help="Number of concurrent workers")
+    args = parser.parse_args()
+    main(args.urls_file, args.output_dir, args.workers)


### PR DESCRIPTION
## Summary
- implement `image_downloader.py` for downloading images concurrently
- document usage in `README.md`

## Testing
- `python3 image_downloader.py -h`
- `python3 image_downloader.py example_urls.txt images --workers 2` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687e7ee6b6c48329a73d704b98c770ba