### PR TITLE
Fix duplicate filenames in downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ python3 image_downloader.py urls.txt downloaded_images
 ```
 
 Use `--workers` to control the number of concurrent downloads.
+If multiple images share a filename, the downloader will append a numerical
+suffix (e.g. `image_1.jpg`) so that all files are saved without overwriting
+each other.

--- a/image_downloader.py
+++ b/image_downloader.py
@@ -55,13 +55,22 @@ def download_image(
 ) -> None:
     """Download a single image to the destination directory."""
     dest.mkdir(parents=True, exist_ok=True)
-    filename = url.split("/")[-1] or "image"
-    target = dest / filename
+    original_name = url.split("/")[-1] or "image"
+    base, ext = os.path.splitext(original_name)
+    filename = original_name
+    target: Path | None = None
 
     try:
         with urlopen(url) as response:
             size = int(response.headers.get("Content-Length", "0") or 0)
             with lock:
+                name = filename
+                i = 1
+                while name in progress or (dest / name).exists():
+                    name = f"{base}_{i}{ext}"
+                    i += 1
+                filename = name
+                target = dest / filename
                 progress[filename] = [0, size]
                 print_progress(counter[0], total, progress)
 


### PR DESCRIPTION
## Summary
- ensure image_downloader adds unique suffixes if a name is reused
- document new behavior in the README

## Testing
- `python -m py_compile image_downloader.py`
- `python image_downloader.py urls.txt downloads --workers 2` (with local http server)

------
https://chatgpt.com/codex/tasks/task_e_687e9fce029483299662ffc6afca1afe