### PR TITLE
Add sample dice-based adventure game

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,20 @@ Use `--workers` to control the number of concurrent downloads.
 If multiple images share a filename, the downloader will append a numerical
 suffix (e.g. `image_1.jpg`) so that all files are saved without overwriting
 each other.
+
+## Adventure Game
+
+`adventure_game.py` is a small command line adventure engine.
+It loads a game description from a JSON file and uses random "dice"
+rolls to determine how long to perform tasks and which option to
+follow next.
+
+### Usage
+
+Run the script with a path to a JSON file:
+
+```bash
+python3 adventure_game.py sample_game.json
+```
+
+A sample game definition is provided in `sample_game.json`.

--- a/adventure_game.py
+++ b/adventure_game.py
@@ -1,0 +1,78 @@
+import argparse
+import json
+import random
+from pathlib import Path
+
+
+def choose_number(max_value: int) -> int:
+    """Return a random integer between 1 and max_value, inclusive."""
+    return random.randint(1, max_value)
+
+
+def print_section(name: str, section: dict) -> str | None:
+    """Print details for a game section and return the next section."""
+
+    print("#" * 30)
+    print(f"Section: {name}")
+    desc = section.get("description")
+    if desc:
+        print(f"Description: {desc}")
+
+    if "max_time" in section:
+        time_val = choose_number(int(section["max_time"]))
+        print(f"max_time: {time_val} minutes")
+    if "speed" in section:
+        speed_val = random.choice(section["speed"])
+        print(f"speed: {speed_val}")
+    if "intensity" in section:
+        intensity_val = random.choice(section["intensity"])
+        print(f"intensity: {intensity_val}")
+    if "count" in section:
+        count_val = choose_number(int(section["count"]))
+        print(f"count: {count_val}")
+
+    options = section.get("options")
+    if not options:
+        return None
+
+    chosen = random.choice(options)
+    option_name = chosen.get("option", "")
+    print(f"Option: {option_name}")
+    option_desc = chosen.get("description")
+    if option_desc:
+        print(f"Description: {option_desc}")
+    input("Press enter when ready to move on\n")
+
+    return chosen.get("next")
+
+
+def run_game(data: dict) -> None:
+    current = "start"
+    while True:
+        section = data.get(current)
+        if section is None:
+            print(f"Section '{current}' not found. Exiting.")
+            return
+
+        name = section.get("name") or current
+        next_section = print_section(name, section)
+
+        if current == "end":
+            return
+
+        if not next_section:
+            print("Next section not specified. Exiting.")
+            return
+        current = next_section
+
+
+def main(json_file: Path) -> None:
+    data = json.loads(json_file.read_text())
+    run_game(data)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Command line adventure game")
+    parser.add_argument("json_file", type=Path, help="Path to JSON game file")
+    args = parser.parse_args()
+    main(args.json_file)

--- a/sample_game.json
+++ b/sample_game.json
@@ -1,0 +1,51 @@
+{
+    "start": {
+        "name": "Start",
+        "description": "The adventure begins.",
+        "options": [
+            {"option": "Walk to the forest", "description": "Take a stroll among the trees.", "next": "alpha"},
+            {"option": "Visit the village", "description": "See what's going on in the village.", "next": "beta"},
+            {"option": "Rest by the river", "description": "Relax and enjoy the water.", "next": "omega"},
+            {"option": "Give up", "description": "End your adventure early.", "next": "end"}
+        ]
+    },
+    "alpha": {
+        "name": "Forest",
+        "description": "Tall trees surround you.",
+        "max_time": 15,
+        "options": [
+            {"option": "Climb a tree", "next": "alpha"},
+            {"option": "Pick berries", "next": "beta"},
+            {"option": "Follow a trail", "next": "omega"},
+            {"option": "Head back", "next": "end"}
+        ]
+    },
+    "beta": {
+        "name": "Village",
+        "description": "The villagers greet you.",
+        "speed": ["slow", "medium", "fast"],
+        "max_time": 10,
+        "options": [
+            {"option": "Browse the market", "next": "alpha"},
+            {"option": "Talk to the elder", "next": "beta"},
+            {"option": "Help with chores", "next": "omega"},
+            {"option": "Leave the village", "next": "end"}
+        ]
+    },
+    "omega": {
+        "name": "River",
+        "description": "The river flows swiftly.",
+        "intensity": ["light", "medium", "hard"],
+        "count": 6,
+        "options": [
+            {"option": "Skip stones", "next": "alpha"},
+            {"option": "Go fishing", "next": "beta"},
+            {"option": "Take a swim", "next": "omega"},
+            {"option": "Follow the river", "next": "end"}
+        ]
+    },
+    "end": {
+        "name": "End",
+        "description": "Your adventure concludes."
+    }
+}


### PR DESCRIPTION
## Summary
- add an example JSON adventure description
- implement `adventure_game.py` to drive the game from JSON
- document the new script and sample file in README
- refactor adventure game printing into `print_section`

## Testing
- `python3 -m py_compile adventure_game.py`
- `yes '' | python3 adventure_game.py sample_game.json > /tmp/game_output && tail -n 20 /tmp/game_output`

------
https://chatgpt.com/codex/tasks/task_e_687eb229f2788329866499a59318a01e