### PR TITLE
Add branching follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,26 @@ python3 adventure_game.py sample_game.json
 ```
 
 A sample game definition is provided in `sample_game.json`.
+
+### Branching follow-up options
+
+Options can include a `followup` section to ask the player a question and
+branch based on the response. Each follow-up contains a `prompt` and a
+`responses` mapping from player input to the next section. If the input
+isn't recognized, a `default` entry may specify where to go next.
+
+Example:
+
+```json
+{
+  "option": "Open the door",
+  "followup": {
+    "prompt": "Were you able to open the door? (yes/no)",
+    "responses": {
+      "yes": "alpha",
+      "no": "beta",
+      "default": "end"
+    }
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ Example:
   }
 }
 ```
+
+When a `followup` block is provided, the option does not need its own
+`next` field because the responses determine the next section.

--- a/adventure_game.py
+++ b/adventure_game.py
@@ -42,8 +42,21 @@ def print_section(name: str, section: dict) -> Optional[str]:
     option_desc = chosen.get("description")
     if option_desc:
         print(f"Description: {option_desc}")
-    input("Press enter when ready to move on\n")
 
+    followup = chosen.get("followup")
+    if followup:
+        prompt = followup.get("prompt", "")
+        answer = input(f"{prompt}\n").strip().lower()
+        responses = followup.get("responses", {})
+        next_section = responses.get(answer)
+        if next_section is None:
+            next_section = responses.get("default")
+        if next_section is None:
+            print("Unrecognized response and no default specified. Exiting.")
+            return None
+        return next_section
+
+    input("Press enter when ready to move on\n")
     return chosen.get("next")
 
 

--- a/sample_game.json
+++ b/sample_game.json
@@ -14,7 +14,18 @@
         "description": "Tall trees surround you.",
         "max_time": 15,
         "options": [
-            {"option": "Climb a tree", "next": "alpha"},
+            {
+                "option": "Climb a tree",
+                "followup": {
+                    "prompt": "Did you reach the top? (yes/no)",
+                    "responses": {
+                        "yes": "beta",
+                        "no": "alpha",
+                        "default": "end"
+                    }
+                },
+                "next": "alpha"
+            },
             {"option": "Pick berries", "next": "beta"},
             {"option": "Follow a trail", "next": "omega"},
             {"option": "Head back", "next": "end"}
@@ -38,7 +49,18 @@
         "intensity": ["light", "medium", "hard"],
         "count": 6,
         "options": [
-            {"option": "Skip stones", "next": "alpha"},
+            {
+                "option": "Skip stones",
+                "followup": {
+                    "prompt": "Did the stone skip? (yes/no)",
+                    "responses": {
+                        "yes": "alpha",
+                        "no": "omega",
+                        "default": "end"
+                    }
+                },
+                "next": "alpha"
+            },
             {"option": "Go fishing", "next": "beta"},
             {"option": "Take a swim", "next": "omega"},
             {"option": "Follow the river", "next": "end"}

--- a/sample_game.json
+++ b/sample_game.json
@@ -23,8 +23,7 @@
                         "no": "alpha",
                         "default": "end"
                     }
-                },
-                "next": "alpha"
+                }
             },
             {"option": "Pick berries", "next": "beta"},
             {"option": "Follow a trail", "next": "omega"},
@@ -58,8 +57,7 @@
                         "no": "omega",
                         "default": "end"
                     }
-                },
-                "next": "alpha"
+                }
             },
             {"option": "Go fishing", "next": "beta"},
             {"option": "Take a swim", "next": "omega"},


### PR DESCRIPTION
## Summary
- support optional `followup` structure for branching after an option
- document follow-up feature in README
- add branching examples to `sample_game.json`

## Testing
- `python3 -m py_compile adventure_game.py image_downloader.py`


------
https://chatgpt.com/codex/tasks/task_e_687fcd24e8388329afb14f31d94ab363