### PR TITLE
Add simple web app interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,5 @@ python3 web_app.py
 ```
 
 Then open `http://localhost:8000` in your browser.  Uploaded games are
-stored in the `games/` directory.
+stored in the `games/` directory. When a game ends, the page includes a
+"Back to home" link so you can return to the list of games.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ When a `followup` block is provided, the option does not need its own
 
 `web_app.py` provides a minimal web interface using only the Python standard library.
 It lets you upload new game JSON files and play them in the browser.
-Each section displays its available options so you can choose how the story proceeds.
+Like the command line version, the web app automatically chooses an option for you at each step of the story.
 Run the server with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ When a `followup` block is provided, the option does not need its own
 
 `web_app.py` provides a minimal web interface using only the Python standard library.
 It lets you upload new game JSON files and play them in the browser.
+Each section displays its available options so you can choose how the story proceeds.
 Run the server with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -65,3 +65,16 @@ Example:
 
 When a `followup` block is provided, the option does not need its own
 `next` field because the responses determine the next section.
+
+## Web Interface
+
+`web_app.py` provides a minimal web interface using only the Python standard library.
+It lets you upload new game JSON files and play them in the browser.
+Run the server with:
+
+```bash
+python3 web_app.py
+```
+
+Then open `http://localhost:8000` in your browser.  Uploaded games are
+stored in the `games/` directory.

--- a/games/sample_game.json
+++ b/games/sample_game.json
@@ -1,0 +1,71 @@
+{
+    "start": {
+        "name": "Start",
+        "description": "The adventure begins.",
+        "options": [
+            {"option": "Walk to the forest", "description": "Take a stroll among the trees.", "next": "alpha"},
+            {"option": "Visit the village", "description": "See what's going on in the village.", "next": "beta"},
+            {"option": "Rest by the river", "description": "Relax and enjoy the water.", "next": "omega"},
+            {"option": "Give up", "description": "End your adventure early.", "next": "end"}
+        ]
+    },
+    "alpha": {
+        "name": "Forest",
+        "description": "Tall trees surround you.",
+        "max_time": 15,
+        "options": [
+            {
+                "option": "Climb a tree",
+                "followup": {
+                    "prompt": "Did you reach the top? (yes/no)",
+                    "responses": {
+                        "yes": "beta",
+                        "no": "alpha",
+                        "default": "end"
+                    }
+                }
+            },
+            {"option": "Pick berries", "next": "beta"},
+            {"option": "Follow a trail", "next": "omega"},
+            {"option": "Head back", "next": "end"}
+        ]
+    },
+    "beta": {
+        "name": "Village",
+        "description": "The villagers greet you.",
+        "speed": ["slow", "medium", "fast"],
+        "max_time": 10,
+        "options": [
+            {"option": "Browse the market", "next": "alpha"},
+            {"option": "Talk to the elder", "next": "beta"},
+            {"option": "Help with chores", "next": "omega"},
+            {"option": "Leave the village", "next": "end"}
+        ]
+    },
+    "omega": {
+        "name": "River",
+        "description": "The river flows swiftly.",
+        "intensity": ["light", "medium", "hard"],
+        "count": 6,
+        "options": [
+            {
+                "option": "Skip stones",
+                "followup": {
+                    "prompt": "Did the stone skip? (yes/no)",
+                    "responses": {
+                        "yes": "alpha",
+                        "no": "omega",
+                        "default": "end"
+                    }
+                }
+            },
+            {"option": "Go fishing", "next": "beta"},
+            {"option": "Take a swim", "next": "omega"},
+            {"option": "Follow the river", "next": "end"}
+        ]
+    },
+    "end": {
+        "name": "End",
+        "description": "Your adventure concludes."
+    }
+}

--- a/web_app.py
+++ b/web_app.py
@@ -80,7 +80,7 @@ def play_page(environ, params):
 
     options = section.get('options')
     if not options:
-        parts.append("<p>The end.</p>")
+        parts.append("<p>The end.</p><p><a href='/'>Back to home</a></p>")
         return render_page("".join(parts))
 
     chosen = random.choice(options)
@@ -105,7 +105,7 @@ def play_page(environ, params):
 
     next_section = chosen.get('next')
     if not next_section:
-        parts.append("<p>No next section. Game over.</p>")
+        parts.append("<p>No next section. Game over.</p><p><a href='/'>Back to home</a></p>")
         return render_page("".join(parts))
 
     body = "".join(parts) + f"""

--- a/web_app.py
+++ b/web_app.py
@@ -58,7 +58,6 @@ def handle_upload(environ):
 def play_page(environ, params):
     game_name = params.get('game', [''])[0]
     section_name = params.get('section', ['start'])[0]
-    choice_idx = params.get('choice', [None])[0]
     data = load_game(game_name)
     section = data.get(section_name)
     if not section:
@@ -84,24 +83,11 @@ def play_page(environ, params):
         parts.append("<p>The end.</p><p><a href='/'>Back to home</a></p>")
         return render_page("".join(parts))
 
-    # If the player has not chosen an option yet, show the list of choices.
-    if choice_idx is None:
-        items = []
-        for idx, opt in enumerate(options):
-            label = html.escape(opt.get('option', f'Option {idx + 1}'))
-            items.append(
-                f"<li><a href='/play?game={game_name}&section={section_name}&choice={idx}'>{label}</a></li>"
-            )
-        parts.append("<ul>" + "\n".join(items) + "</ul>")
-        return render_page("".join(parts))
-
-    # Validate the chosen index.
-    try:
-        idx = int(choice_idx)
-        chosen = options[idx]
-    except (ValueError, IndexError):
-        parts.append("<p>Invalid choice.</p><p><a href='/'>Back to home</a></p>")
-        return render_page("".join(parts))
+    # Randomly select an option like the command line version.
+    chosen = random.choice(options)
+    opt_name = chosen.get('option')
+    if opt_name:
+        parts.append(f"<p>Option: {html.escape(opt_name)}</p>")
 
     # Show the result of the chosen option.
     opt_desc = chosen.get('description')

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,161 @@
+import json
+import random
+import cgi
+import html
+from pathlib import Path
+from urllib.parse import parse_qs
+from wsgiref.simple_server import make_server
+
+GAMES_DIR = Path(__file__).parent / "games"
+GAMES_DIR.mkdir(exist_ok=True)
+
+
+def choose_number(max_value: int) -> int:
+    return random.randint(1, max_value)
+
+
+def load_game(name: str) -> dict:
+    game_file = GAMES_DIR / name
+    return json.loads(game_file.read_text())
+
+
+def render_page(body: str, status: str = "200 OK", headers=None):
+    headers = headers or []
+    headers.append(("Content-Type", "text/html; charset=utf-8"))
+    return status, headers, body.encode("utf-8")
+
+
+def index_page():
+    items = []
+    for p in GAMES_DIR.glob("*.json"):
+        items.append(f"<li><a href='/play?game={p.name}'>Play {p.name}</a></li>")
+    games_list = "\n".join(items) or "<li>No games uploaded</li>"
+    body = f"""
+    <h1>Adventure Games</h1>
+    <ul>{games_list}</ul>
+    <h2>Upload New Game</h2>
+    <form method='POST' action='/upload' enctype='multipart/form-data'>
+        <input type='file' name='file'/>
+        <button type='submit'>Upload</button>
+    </form>
+    """
+    return render_page(body)
+
+
+def handle_upload(environ):
+    form = cgi.FieldStorage(fp=environ['wsgi.input'], environ=environ,
+                            keep_blank_values=True)
+    file_item = form['file']
+    if file_item.filename:
+        dest = GAMES_DIR / Path(file_item.filename).name
+        dest.write_bytes(file_item.file.read())
+        body = "<p>Upload successful.</p><a href='/'>Back to home</a>"
+    else:
+        body = "<p>No file uploaded.</p><a href='/'>Back to home</a>"
+    return render_page(body)
+
+
+def play_page(environ, params):
+    game_name = params.get('game', [''])[0]
+    section_name = params.get('section', ['start'])[0]
+    data = load_game(game_name)
+    section = data.get(section_name)
+    if not section:
+        return render_page("<p>Section not found.</p>")
+
+    parts = ["<h2>{}</h2>".format(section.get('name', section_name))]
+    desc = section.get('description')
+    if desc:
+        parts.append(f"<p>{desc}</p>")
+
+    if 'max_time' in section:
+        time_val = choose_number(int(section['max_time']))
+        parts.append(f"<p>max_time: {time_val} minutes</p>")
+    if 'speed' in section:
+        parts.append(f"<p>speed: {random.choice(section['speed'])}</p>")
+    if 'intensity' in section:
+        parts.append(f"<p>intensity: {random.choice(section['intensity'])}</p>")
+    if 'count' in section:
+        parts.append(f"<p>count: {choose_number(int(section['count']))}</p>")
+
+    options = section.get('options')
+    if not options:
+        parts.append("<p>The end.</p>")
+        return render_page("".join(parts))
+
+    chosen = random.choice(options)
+    opt_desc = chosen.get('description')
+    if opt_desc:
+        parts.append(f"<p>{opt_desc}</p>")
+
+    followup = chosen.get('followup')
+    if followup:
+        prompt = followup.get('prompt', '')
+        followup_json = json.dumps(followup)
+        body = "".join(parts) + f"""
+        <form method='POST' action='/play'>
+            <p>{prompt}</p>
+            <input type='hidden' name='game' value='{game_name}'/>
+            <input type='hidden' name='followup' value='{html.escape(followup_json)}'/>
+            <input type='text' name='answer'/>
+            <button type='submit'>Submit</button>
+        </form>
+        """
+        return render_page(body)
+
+    next_section = chosen.get('next')
+    if not next_section:
+        parts.append("<p>No next section. Game over.</p>")
+        return render_page("".join(parts))
+
+    body = "".join(parts) + f"""
+    <a href='/play?game={game_name}&section={next_section}'>Continue</a>
+    """
+    return render_page(body)
+
+
+def handle_followup(params):
+    game_name = params.get('game', [''])[0]
+    followup_json = params.get('followup', [''])[0]
+    answer = params.get('answer', [''])[0].strip().lower()
+    try:
+        followup = json.loads(followup_json)
+    except json.JSONDecodeError:
+        return render_page("<p>Error reading followup.</p>")
+    responses = followup.get('responses', {})
+    next_section = responses.get(answer) or responses.get('default')
+    if not next_section:
+        return render_page("<p>Unrecognized response and no default specified.</p>")
+    headers = [('Location', f'/play?game={game_name}&section={next_section}')]
+    return '303 See Other', headers, b''
+
+
+def application(environ, start_response):
+    path = environ.get('PATH_INFO', '/')
+    method = environ.get('REQUEST_METHOD')
+    if path == '/':
+        status, headers, body = index_page()
+    elif path == '/upload' and method == 'POST':
+        status, headers, body = handle_upload(environ)
+    elif path == '/play' and method == 'GET':
+        params = parse_qs(environ.get('QUERY_STRING', ''))
+        status, headers, body = play_page(environ, params)
+    elif path == '/play' and method == 'POST':
+        try:
+            size = int(environ.get('CONTENT_LENGTH', 0))
+        except ValueError:
+            size = 0
+        body_bytes = environ['wsgi.input'].read(size)
+        params = parse_qs(body_bytes.decode())
+        status, headers, body = handle_followup(params)
+    else:
+        status, headers, body = render_page('<p>Not Found</p>', '404 Not Found')
+
+    start_response(status, headers)
+    return [body]
+
+
+if __name__ == '__main__':
+    with make_server('', 8000, application) as server:
+        print("Serving on http://localhost:8000")
+        server.serve_forever()


### PR DESCRIPTION
## Summary
- create `web_app.py` with a minimal WSGI web interface
- add `games/` directory with a sample game
- document how to use the web interface in `README.md`

## Testing
- `python3 -m py_compile web_app.py`
- `python3 -m py_compile adventure_game.py`
- `python3 web_app.py` *(manual run to start server)*

------
https://chatgpt.com/codex/tasks/task_e_68814739a05c83299a061bd3d5c9e586