### PR TITLE
Add Cloud Run deployment setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Use official lightweight Python image.
+FROM python:3.11-slim
+
+# Allow statements and log messages to immediately appear in the logs
+ENV PYTHONUNBUFFERED=1
+
+# Install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY . /app
+WORKDIR /app
+
+# Command to run the web service
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 web_app:application

--- a/README.md
+++ b/README.md
@@ -80,3 +80,27 @@ python3 web_app.py
 Then open `http://localhost:8000` in your browser.  Uploaded games are
 stored in the `games/` directory. When a game ends, the page includes a
 "Back to home" link so you can return to the list of games.
+
+## Deploying on Cloud Run
+
+To run the web app on [Google Cloud Run](https://cloud.google.com/run), build
+a container image and deploy it using the `gcloud` CLI.
+
+1. Build and push the image (replace `PROJECT_ID` with your project):
+
+   ```bash
+   gcloud builds submit --tag gcr.io/PROJECT_ID/adventure-game .
+   ```
+
+2. Deploy the service:
+
+   ```bash
+   gcloud run deploy adventure-game \
+       --image gcr.io/PROJECT_ID/adventure-game \
+       --platform managed --region REGION --allow-unauthenticated
+   ```
+
+Cloud Run sets the `PORT` environment variable automatically. The included
+`Dockerfile` starts the app with Gunicorn listening on that port. After the
+deployment finishes, the command output shows the service URL where you can
+play the game online.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Only external dependency for production server
+gunicorn

--- a/web_app.py
+++ b/web_app.py
@@ -2,6 +2,7 @@ import json
 import random
 import cgi
 import html
+import os
 from pathlib import Path
 from urllib.parse import parse_qs
 from wsgiref.simple_server import make_server
@@ -162,6 +163,7 @@ def application(environ, start_response):
 
 
 if __name__ == '__main__':
-    with make_server('', 8000, application) as server:
-        print("Serving on http://localhost:8000")
+    port = int(os.environ.get('PORT', '8000'))
+    with make_server('', port, application) as server:
+        print(f"Serving on http://localhost:{port}")
         server.serve_forever()


### PR DESCRIPTION
## Summary
- add Dockerfile and requirements.txt for Cloud Run container
- adjust web_app to read PORT from environment
- document Cloud Run deployment steps in README

## Testing
- `python3 -m py_compile web_app.py adventure_game.py image_downloader.py`
- `PORT=9000 python3 web_app.py & sleep 2; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6881542e07c88329906ae05849e8bfa1