### PR TITLE
Fix Python 3.13 compatibility

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -1,6 +1,7 @@
 import json
 import random
-import cgi
+from email.parser import BytesParser
+from email.policy import default
 import html
 import os
 from pathlib import Path
@@ -43,13 +44,44 @@ def index_page():
     return render_page(body)
 
 
+def parse_multipart(environ):
+    """Parse multipart/form-data from a WSGI environ.
+
+    Returns a mapping of field name to a dict with optional 'filename' and
+    'content' keys. Only the request body is read; callers should not read
+    from ``wsgi.input`` afterwards.
+    """
+    content_type = environ.get('CONTENT_TYPE', '')
+    if not content_type.startswith('multipart/form-data'):
+        return {}
+
+    content_length = int(environ.get('CONTENT_LENGTH', 0))
+    body = environ['wsgi.input'].read(content_length)
+
+    parser = BytesParser(policy=default)
+    message = parser.parsebytes(
+        f"Content-Type: {content_type}\r\n\r\n".encode() + body
+    )
+
+    form = {}
+    for part in message.iter_parts():
+        name = part.get_param('name', header='content-disposition')
+        if not name:
+            continue
+        filename = part.get_filename()
+        form[name] = {
+            'filename': filename,
+            'content': part.get_payload(decode=True),
+        }
+    return form
+
+
 def handle_upload(environ):
-    form = cgi.FieldStorage(fp=environ['wsgi.input'], environ=environ,
-                            keep_blank_values=True)
-    file_item = form['file']
-    if file_item.filename:
-        dest = GAMES_DIR / Path(file_item.filename).name
-        dest.write_bytes(file_item.file.read())
+    form = parse_multipart(environ)
+    file_item = form.get('file')
+    if file_item and file_item.get('filename'):
+        dest = GAMES_DIR / Path(file_item['filename']).name
+        dest.write_bytes(file_item['content'])
         body = "<p>Upload successful.</p><a href='/'>Back to home</a>"
     else:
         body = "<p>No file uploaded.</p><a href='/'>Back to home</a>"


### PR DESCRIPTION
## Summary
- remove deprecated `cgi` usage in `web_app.py`
- implement a minimal multipart parser using the `email` module

## Testing
- `python3 -m py_compile web_app.py adventure_game.py image_downloader.py`
- `python3 web_app.py & sleep 2; kill $!`
- `python3 - <<'EOF'
from web_app import parse_multipart
from io import BytesIO

environ = {
    'CONTENT_TYPE': 'multipart/form-data; boundary=123',
    'CONTENT_LENGTH': '156',
    'wsgi.input': BytesIO(b'--123\r\nContent-Disposition: form-data; name="file"; filename="a.txt"\r\nContent-Type: text/plain\r\n\r\nhello\r\n--123--\r\n'),
}
print(parse_multipart(environ))
EOF

------
https://chatgpt.com/codex/tasks/task_e_6883de12674083298dfb2e59a0990e46